### PR TITLE
Allow the service account a function runs as to be specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog][keepachangelog-site],
 and this project adheres to [Semantic Versioning][semver-site].
 
 
+## Unreleased
+
+### Added
+
+- Ability to specify a service account for functions to run as
+
 ## 0.1.0 - 2018-08-08
 
 ### Added

--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,7 @@ resource "google_cloudfunctions_function" "main" {
   environment_variables = "${var.function_environment_variables}"
   project               = "${var.project_id}"
   region                = "${var.region}"
+  service_account_email = "${var.function_service_account_email}"
 }
 
 data "archive_file" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,12 @@ variable "function_timeout_s" {
   description = "The amount of time in seconds allotted for the execution of the function."
 }
 
+variable "function_service_account_email" {
+  type        = "string"
+  default     = ""
+  description = "The service account to run the function as."
+}
+
 variable "bucket_name" {
   type        = "string"
   default     = ""


### PR DESCRIPTION
Exposes [service_account_email](https://www.terraform.io/docs/providers/google/r/cloudfunctions_function.html#service_account_email) attribute of `google_cloudfunctions_function` resource.