### PR TITLE
use new event function version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning][semver-site].
 
 ## [Unreleased]
 
+### Added
+
+- The `function_source_dependent_files` variable is passed on to the `event-function` module's `source_dependent_files` variable. [#28]
+
 ## [1.2.0] - 2019-11-20
 
 ### Added
@@ -76,6 +80,7 @@ and this project adheres to [Semantic Versioning][semver-site].
 [0.2.0]: https://github.com/terraform-google-modules/terraform-google-scheduled-function/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/terraform-google-modules/terraform-google-scheduled-function/releases/tag/v0.1.0
 
+[#28]: https://github.com/terraform-google-modules/terraform-google-scheduled-function/pull/28
 [#22]: https://github.com/terraform-google-modules/terraform-google-scheduled-function/pull/22
 [#21]: https://github.com/terraform-google-modules/terraform-google-scheduled-function/pull/21
 [#20]: https://github.com/terraform-google-modules/terraform-google-scheduled-function/pull/20

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Then perform the following commands on the root folder:
 | function\_runtime | The runtime in which the function will be executed. | string | `"nodejs6"` | no |
 | function\_service\_account\_email | The service account to run the function as. | string | `""` | no |
 | function\_source\_archive\_bucket\_labels | A set of key/value label pairs to assign to the function source archive bucket. | map(string) | `<map>` | no |
+| function\_source\_dependent\_files | A list of any terraform created `local_file`s that the module will wait for before creating the archive. | object | `<list>` | no |
 | function\_source\_directory | The contents of this directory will be archived and used as the function source. | string | n/a | yes |
 | function\_timeout\_s | The amount of time in seconds allotted for the execution of the function. | number | `"60"` | no |
 | job\_description | Addition text to describet the job | string | `""` | no |

--- a/examples/pubsub_scheduled/main.tf
+++ b/examples/pubsub_scheduled/main.tf
@@ -24,6 +24,11 @@ provider "google-beta" {
   region  = var.region
 }
 
+resource "random_pet" "main" {
+  length    = 2
+  separator = "-"
+}
+
 module "pubsub_scheduled_example" {
   providers = {
     google = google-beta
@@ -31,11 +36,11 @@ module "pubsub_scheduled_example" {
 
   source                    = "../../"
   project_id                = var.project_id
-  job_name                  = "pubsub-example"
+  job_name                  = "pubsub-example-${random_pet.main.id}"
   job_schedule              = "*/5 * * * *"
   function_entry_point      = "doSomething"
   function_source_directory = "${path.module}/function_source"
-  function_name             = "testfunction-foo"
+  function_name             = "testfunction-${random_pet.main.id}"
   region                    = var.region
-  topic_name                = "pubsub_example_topic"
+  topic_name                = "pubsub_example_topic_${random_pet.main.id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -48,8 +48,10 @@ module "pubsub_topic" {
  *****************************************/
 
 module "main" {
-  source  = "terraform-google-modules/event-function/google"
-  version = "~> 1.1"
+  # TODO update version once event-function is released with new functionality
+  source = "github.com/taylorludwig/terraform-google-event-function?ref=feature%2F37-terraform-created-files-in-archive"
+  # source  = "terraform-google-modules/event-function/google"
+  # version = "~> 1.1"
 
   entry_point = var.function_entry_point
   event_trigger = {
@@ -61,6 +63,8 @@ module "main" {
   region           = var.region
   runtime          = var.function_runtime
   source_directory = var.function_source_directory
+
+  source_dependent_files = var.function_source_dependent_files
 
   available_memory_mb                = var.function_available_memory_mb
   bucket_force_destroy               = var.bucket_force_destroy

--- a/main.tf
+++ b/main.tf
@@ -48,10 +48,8 @@ module "pubsub_topic" {
  *****************************************/
 
 module "main" {
-  # TODO update version once event-function is released with new functionality
-  source = "github.com/taylorludwig/terraform-google-event-function?ref=feature%2F37-terraform-created-files-in-archive"
-  # source  = "terraform-google-modules/event-function/google"
-  # version = "~> 1.1"
+  source  = "terraform-google-modules/event-function/google"
+  version = "~> 1.2"
 
   entry_point = var.function_entry_point
   event_trigger = {

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.13.0"
+  version = "~> 2.12.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.13.0"
+  version = "~> 2.12.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,15 @@ variable "function_source_directory" {
   description = "The contents of this directory will be archived and used as the function source."
 }
 
+variable "function_source_dependent_files" {
+  type = list(object({
+    filename = string
+    id       = string
+  }))
+  description = "A list of any terraform created `local_file`s that the module will wait for before creating the archive."
+  default     = []
+}
+
 variable "function_timeout_s" {
   type        = number
   default     = 60


### PR DESCRIPTION
~~Needs https://github.com/terraform-google-modules/terraform-google-event-function/pull/38 to be released first.~~

~~Then `source` in `main.tf` should be updated.~~

`google-event-function` has been released

Once this is released we can use the functionality in a proper fix to https://github.com/terraform-google-modules/terraform-google-slo/issues/7 