### PR TITLE
Update variable "bucket_force_destroy" (Quoted type constraints are deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| bucket\_force\_destroy | When deleting the GCS bucket containing the cloud function, delete all objects in the bucket first. | string | `"true"` | no |
+| bucket\_force\_destroy | When deleting the GCS bucket containing the cloud function, delete all objects in the bucket first. | string | `true` | no |
 | bucket\_name | The name to apply to the bucket. Will default to a string of <project-id>-scheduled-function-XXXX> with XXXX being random characters. | string | `""` | no |
 | function\_available\_memory\_mb | The amount of memory in megabytes allotted for the function to use. | number | `"256"` | no |
 | function\_description | The description of the function. | string | `"Processes log export events provided through a Pub/Sub topic subscription."` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -117,8 +117,8 @@ variable "bucket_name" {
 }
 
 variable "bucket_force_destroy" {
-  type        = "string"
-  default     = "true"
+  type        = string
+  default     = true
   description = "When deleting the GCS bucket containing the cloud function, delete all objects in the bucket first."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -117,7 +117,7 @@ variable "bucket_name" {
 }
 
 variable "bucket_force_destroy" {
-  type        = string
+  type        = bool
   default     = true
   description = "When deleting the GCS bucket containing the cloud function, delete all objects in the bucket first."
 }


### PR DESCRIPTION
Warning: Quoted type constraints are deprecated

  on .terraform/modules/slo_generator.slo-hp-fr-availability.slo_cloud_function/variables.tf line 120, in variable "bucket_force_destroy":
 120:   type        = "string"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "string".

(and 8 more similar warnings elsewhere)