### PR TITLE
feat: add folder clean up

### DIFF
--- a/modules/project_cleanup/function_source/go.mod
+++ b/modules/project_cleanup/function_source/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-google-modules/terraform-google-scheduled-function/m
 go 1.13
 
 require (
-	golang.org/x/net v0.0.0-20190318221613-d196dffd7c2b
-	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
-	google.golang.org/api v0.1.0
+	golang.org/x/net v0.0.0-20200822124328-c89045814202
+	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
+	google.golang.org/api v0.35.0
 )

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -17,7 +17,8 @@
 locals {
   int_required_roles = [
     "roles/storage.admin",
-    "roles/pubsub.editor",
+    "roles/pubsub.admin",
+    "roles/resourcemanager.projectIamAdmin",
     "roles/cloudscheduler.admin",
     "roles/cloudfunctions.developer",
     "roles/iam.serviceAccountUser",

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.35.0"
+  version = "~> 3.35"
 }
 
 provider "google-beta" {
-  version = "~> 3.35.0"
+  version = "~> 3.35"
 }


### PR DESCRIPTION
Currently cleanup does not delete folders that are created during test CI runs. This can result in `MAX_CHILD_FOLDERS_VIOLATION` and require manual clean up. This PR address this by 
- removing all folders that are grandchildren of `TARGET_FOLDER_ID` 
- if a folder is not empty of any reason (exclude label/project age) delete fails as expected and is logged