### PR TITLE
fix: add grant_token_creator flag for pubsub 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Then perform the following commands on the root folder:
 | function\_source\_dependent\_files | A list of any terraform created `local_file`s that the module will wait for before creating the archive. | object | `<list>` | no |
 | function\_source\_directory | The contents of this directory will be archived and used as the function source. | string | n/a | yes |
 | function\_timeout\_s | The amount of time in seconds allotted for the execution of the function. | number | `"60"` | no |
+| grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA | bool | `"false"` | no |
 | job\_description | Addition text to describe the job | string | `""` | no |
 | job\_name | The name of the scheduled job to run | string | `"null"` | no |
 | job\_schedule | The job frequency, in cron syntax | string | `"*/2 * * * *"` | no |

--- a/main.tf
+++ b/main.tf
@@ -39,11 +39,12 @@ resource "google_cloud_scheduler_job" "job" {
  *****************************************/
 
 module "pubsub_topic" {
-  source       = "terraform-google-modules/pubsub/google"
-  version      = "~> 1.0"
-  topic        = var.topic_name
-  project_id   = var.project_id
-  create_topic = var.scheduler_job == null ? true : false
+  source              = "terraform-google-modules/pubsub/google"
+  version             = "~> 1.0"
+  topic               = var.topic_name
+  project_id          = var.project_id
+  create_topic        = var.scheduler_job == null ? true : false
+  grant_token_creator = var.grant_token_creator
 }
 
 /******************************************

--- a/variables.tf
+++ b/variables.tf
@@ -155,3 +155,9 @@ variable "scheduler_job" {
   description = "An existing Cloud Scheduler job instance"
   default     = null
 }
+
+variable "grant_token_creator" {
+  type        = bool
+  description = "Specify true if you want to add token creator role to the default Pub/Sub SA"
+  default     = false
+}


### PR DESCRIPTION
Is necessary configure variable grant_token_creator in module pubsub to with value false.

Analysis with checkov detect vulnerability

> Check: CKV_GCP_41: "Ensure that IAM users are not assigned the Service Account User or Service Account Token Creator roles at project level"
	FAILED for resource: google_project_iam_member.token_creator_binding
	File: /tfplan.json:390-395
	Guide: https://docs.bridgecrew.io/docs/bc_gcp_iam_3
		391 |                   "values": {
		392 |                     "condition": [],
		393 |                     "member": "serviceAccount:service-97749614032@gcp-sa-pubsub.iam.gserviceaccount.com",
		394 |                     "project": "tc-sc-bi-bigdata-dp-pmo-dev",
		395 |                     "role": "roles/iam.serviceAccountTokenCreator"
Check: CKV_GCP_49: "Ensure no roles that enable to impersonate and manage all service accounts are used at a project level"
	FAILED for resource: google_project_iam_member.token_creator_binding
	File: /tfplan.json:390-395
	Guide: https://docs.bridgecrew.io/docs/bc_gcp_iam_10
		391 |                   "values": {
		392 |                     "condition": [],
		393 |                     "member": "serviceAccount:service-97749614032@gcp-sa-pubsub.iam.gserviceaccount.com",
		394 |                     "project": "tc-sc-bi-bigdata-dp-pmo-dev",
		395 |                     "role": "roles/iam.serviceAccountTokenCreator"